### PR TITLE
ci: ensure safety checks properly prevent releasing an already released version

### DIFF
--- a/.github/workflows/flow-release-legacy-images.yaml
+++ b/.github/workflows/flow-release-legacy-images.yaml
@@ -96,6 +96,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout Code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Install GH CLI
         uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
         with:
@@ -106,7 +109,7 @@ jobs:
 
       - name: Check for Existing Releases
         run: |
-          if gh release view v${{ needs.versions.outputs.runner }} >/dev/null 2>&1; then
+          if gh release view v${{ needs.versions.outputs.runner }} --json id >/dev/null 2>&1; then
             echo "::error title=Release Version::Release v${{ needs.versions.outputs.runner }} already exists and may not be redeployed."
             exit 1
           fi

--- a/.github/workflows/zxcron-automatic-releases.yaml
+++ b/.github/workflows/zxcron-automatic-releases.yaml
@@ -46,6 +46,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout Code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Install GH CLI
         uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
         with:
@@ -58,7 +61,7 @@ jobs:
         id: release
         run: |
           NEEDED="true"
-          if gh release view v${{ needs.versions.outputs.runner }} >/dev/null 2>&1; then
+          if gh release view v${{ needs.versions.outputs.runner }} --json id >/dev/null 2>&1; then
             echo "::info title=Release Version::Release v${{ needs.versions.outputs.runner }} already exists and may not be redeployed."
             NEEDED="false"
           fi


### PR DESCRIPTION
## Description

This pull request changes the following:

* Ensure the safety check steps and the cron task steps work correctly and prevent attempting to release an already released version.

### Related Issues

* Closes #17 
