### PR TITLE
feat: remove python3 from the tool cache and ensure docker compose is installed

### DIFF
--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -114,11 +114,6 @@ jobs:
       - name: Clear Hosted Tool Cache
         run: rm -rvf "${{ runner.tool_cache }}"/*
 
-      - name: Setup Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
-        with:
-          python-version: '3.10'
-
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
 
@@ -127,6 +122,12 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+
+      - name: Setup Java
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        with:
+          distribution: temurin
+          java-version: 21.0.1
 
       - name: Setup NodeJS 16
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -148,6 +149,11 @@ jobs:
         with:
           node-version: 22
 
+      - name: Setup GoLang 1.20
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: 1.20
+
       - name: Setup Kind
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
@@ -160,9 +166,6 @@ jobs:
 
       - name: Setup Helm Latest
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
-
-      - name: Setup QEmu Support
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: Setup Docker Buildx Support
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1

--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -121,13 +121,13 @@ jobs:
         uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: temurin
-          java-version: 21
+          java-version: "21"
 
       - name: Setup Java
         uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: temurin
-          java-version: 21.0.1
+          java-version: "21.0.1"
 
       - name: Setup NodeJS 16
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -152,7 +152,7 @@ jobs:
       - name: Setup GoLang 1.20
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Setup Kind
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0

--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -85,6 +85,8 @@ RUN apt-get update -y \
     zip \
     gzip \
     jq \
+    python3-pip \
+    htop \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -100,6 +102,15 @@ RUN export ARCH=${TARGETARCH} \
     && curl -sL https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${ARCH}.tar.gz \
         | tar -xz --wildcards --strip-components=2 -C /usr/local/bin "*/bin/gh" \
     && chmod +x /usr/local/bin/gh
+
+ARG COMPOSE_VERSION=2.29.2
+RUN export RUNNER_ARCH=${TARGETARCH} \
+    && if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
+    && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
+    && mkdir -p /usr/local/lib/docker/cli-plugins \
+    && curl -fLo /usr/local/lib/docker/cli-plugins/docker-compose \
+        "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-${RUNNER_ARCH}" \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 #########################################
 ## End OS Software Customizations      ##
 #########################################

--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -105,11 +105,11 @@ RUN export ARCH=${TARGETARCH} \
 
 ARG COMPOSE_VERSION=2.29.2
 RUN export RUNNER_ARCH=${TARGETARCH} \
-    && if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
-    && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
+    && if [ "${RUNNER_ARCH}" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
+    && if [ "${RUNNER_ARCH}" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
     && mkdir -p /usr/local/lib/docker/cli-plugins \
     && curl -fLo /usr/local/lib/docker/cli-plugins/docker-compose \
-        "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-${RUNNER_ARCH}" \
+        "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-${DOCKER_ARCH}" \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 #########################################
 ## End OS Software Customizations      ##


### PR DESCRIPTION
## Description

This pull request changes the following:

* Removes python3 from the cache.
* Installs native python3-pip and htop
* Installs docker compose plugin
* Adds GoLang 1.20 to the tool cache
* Adds explicit Java 21.0.1 version to the tool cache

### Related Issues

* Closes #26 
