### PR TITLE
feat: prebake additional dependencies and hosted tool cache items

### DIFF
--- a/.github/workflows/zxc-build-legacy-images.yaml
+++ b/.github/workflows/zxc-build-legacy-images.yaml
@@ -254,7 +254,7 @@ jobs:
           
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
             DOCKER_REGISTRY_PREFIX="local"
-            IMG_RESULT="load"
+            IMG_RESULT="cache"
           fi
           
           echo "prefix=${DOCKER_REGISTRY_PREFIX}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -139,6 +139,11 @@ jobs:
         with:
           node-version: 18
 
+      - name: Setup NodeJS 19
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: 19
+
       - name: Setup NodeJS 20
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
@@ -153,6 +158,11 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.20"
+
+      - name: Setup GoLang 1.21.0
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: "1.21.0"
 
       - name: Setup Kind
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0

--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -262,7 +262,6 @@ jobs:
           context: ${{ github.workspace }}/scaleset/runner
           platforms: ${{ inputs.platforms }}
           push: ${{ steps.registry.outputs.operation == 'push' }}
-          load: ${{ steps.registry.outputs.operation == 'load' }}
           tags: |
             ${{ steps.registry.outputs.prefix }}/scaleset-runner:${{ inputs.base-os-image }}
             ${{ steps.registry.outputs.prefix }}/scaleset-runner:v${{ inputs.runner-version }}-${{ inputs.base-os-image }}

--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -1,5 +1,5 @@
 # Source: https://github.com/dotnet/dotnet-docker
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
+FROM mcr.microsoft.com/dotnet/runtime:6.0-jammy as build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -87,6 +87,8 @@ RUN apt-get update -y \
     jq \
     python3-pip \
     htop \
+    psmisc \
+    openssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Add psmisc and openssh-client aptitude packages
* Switch to using mcr.microsoft.com/dotnet/runtime base image instead of mcr.microsoft.com/dotnet/runtime-deps
* Add NodeJS 19 and GoLang 1.21.0 to the hosted tool cache

### Related Issues

* Closes #28
