### PR TITLE
fix: ensure docker image tags use include the build version

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -46,6 +46,7 @@ jobs:
       build-dind-image: true
       build-dind-rootless-image: false
       base-os-image: ubuntu-22.04
+      tag-version: ${{ needs.versions.outputs.runner }}
       runner-version: ${{ needs.versions.outputs.runner }}
       runner-container-hooks-version: ${{ needs.versions.outputs.hooks }}
       docker-version: 24.0.9
@@ -59,6 +60,7 @@ jobs:
       - versions
     with:
       base-os-image: ubuntu-22.04
+      tag-version: ${{ needs.versions.outputs.runner }}
       runner-version: ${{ needs.versions.outputs.runner }}
       runner-container-hooks-version: ${{ needs.versions.outputs.hooks }}
       docker-version: 25.0.5

--- a/.github/workflows/flow-release-legacy-images.yaml
+++ b/.github/workflows/flow-release-legacy-images.yaml
@@ -128,6 +128,7 @@ jobs:
     with:
       custom-job-label: "Release"
       base-os-image: ${{ matrix.base-os-image }}
+      tag-version: ${{ needs.versions.outputs.tag }}
       runner-version: ${{ needs.versions.outputs.runner }}
       runner-container-hooks-version: ${{ needs.versions.outputs.hooks }}
       docker-version: ${{ github.event.inputs.docker-version || '25.0.5' }}

--- a/.github/workflows/flow-release-scaleset-images.yaml
+++ b/.github/workflows/flow-release-scaleset-images.yaml
@@ -123,6 +123,7 @@ jobs:
     with:
       custom-job-label: "Release"
       base-os-image: ${{ matrix.base-os-image }}
+      tag-version: ${{ needs.versions.outputs.tag }}
       runner-version: ${{ needs.versions.outputs.runner }}
       runner-container-hooks-version: ${{ needs.versions.outputs.hooks }}
       docker-version: ${{ github.event.inputs.docker-version || '25.0.5' }}

--- a/.github/workflows/zxc-build-legacy-images.yaml
+++ b/.github/workflows/zxc-build-legacy-images.yaml
@@ -31,6 +31,12 @@ on:
         type: string
         required: true
 
+      ## The tag version to be used
+      tag-version:
+        description: "Tag Version:"
+        type: string
+        required: true
+
       ## Upstream Github Action Runner Version
       runner-version:
         description: "Runner Version:"
@@ -95,6 +101,7 @@ defaults:
 env:
   OS_IMAGE: ${{ inputs.base-os-image }}
   RUNNER_VERSION: ${{ inputs.runner-version }}
+  TAG_VERSION: ${{ inputs.tag-version || inputs.runner-version }}
   RUNNER_CONTAINER_HOOKS_VERSION: ${{ inputs.runner-container-hooks-version }}
   DOCKER_VERSION: ${{ inputs.docker-version }}
   PLATFORMS: ${{ inputs.platforms }}

--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -30,6 +30,12 @@ on:
         type: string
         required: true
 
+      ## The tag version to be used
+      tag-version:
+        description: "Tag Version:"
+        type: string
+        required: true
+
       ## Upstream Github Action Runner Version
       runner-version:
         description: "Runner Version:"
@@ -268,7 +274,7 @@ jobs:
           load: ${{ steps.registry.outputs.operation == 'load' }}
           tags: |
             ${{ steps.registry.outputs.prefix }}/scaleset-runner:${{ inputs.base-os-image }}
-            ${{ steps.registry.outputs.prefix }}/scaleset-runner:v${{ inputs.runner-version }}-${{ inputs.base-os-image }}
+            ${{ steps.registry.outputs.prefix }}/scaleset-runner:v${{ inputs.tag-version || inputs.runner-version }}-${{ inputs.base-os-image }}
           build-args: |
             TARGETOS=linux
             TARGETARCH=amd64

--- a/legacy/runner/Makefile
+++ b/legacy/runner/Makefile
@@ -6,6 +6,7 @@ DIND_ROOTLESS_RUNNER_NAME ?= ${DOCKER_USER}/actions-runner-dind-rootless
 OS_IMAGE ?= ubuntu-22.04
 TARGETPLATFORM ?= $(shell arch)
 
+TAG_VERSION ?= 2.318.0
 RUNNER_VERSION ?= 2.318.0
 RUNNER_CONTAINER_HOOKS_VERSION ?= 0.6.1
 DOCKER_VERSION ?= 24.0.7
@@ -102,7 +103,7 @@ docker-buildx-set:
 	  --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
 	  -f actions-runner.${OS_IMAGE}.dockerfile \
 	  -t "${DEFAULT_RUNNER_NAME}:${OS_IMAGE}" \
-	  -t "${DEFAULT_RUNNER_NAME}:v${RUNNER_VERSION}-${OS_IMAGE}" \
+	  -t "${DEFAULT_RUNNER_NAME}:v${TAG_VERSION}-${OS_IMAGE}" \
 	  . ${PUSH_ARG}
 	${DOCKER} buildx build --platform ${PLATFORMS} \
 	  --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
@@ -110,7 +111,7 @@ docker-buildx-set:
 	  --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
 	  -f actions-runner-dind.${OS_IMAGE}.dockerfile \
 	  -t "${DIND_RUNNER_NAME}:${OS_IMAGE}" \
-	  -t "${DIND_RUNNER_NAME}:v${RUNNER_VERSION}-${OS_IMAGE}" \
+	  -t "${DIND_RUNNER_NAME}:v${TAG_VERSION}-${OS_IMAGE}" \
 	  . ${PUSH_ARG}
 	${DOCKER} buildx build --platform ${PLATFORMS} \
 	  --build-arg RUNNER_VERSION=${RUNNER_VERSION} \
@@ -118,7 +119,7 @@ docker-buildx-set:
 	  --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
 	  -f actions-runner-dind-rootless.${OS_IMAGE}.dockerfile \
 	  -t "${DIND_ROOTLESS_RUNNER_NAME}:${OS_IMAGE}" \
-	  -t "${DIND_ROOTLESS_RUNNER_NAME}:v${RUNNER_VERSION}-${OS_IMAGE}" \
+	  -t "${DIND_ROOTLESS_RUNNER_NAME}:v${TAG_VERSION}-${OS_IMAGE}" \
 	  . ${PUSH_ARG}
 
 docker-buildx-default:
@@ -133,7 +134,7 @@ docker-buildx-default:
 	  --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
 	  -f actions-runner.${OS_IMAGE}.dockerfile \
 	  -t "${DEFAULT_RUNNER_NAME}:${OS_IMAGE}" \
-	  -t "${DEFAULT_RUNNER_NAME}:v${RUNNER_VERSION}-${OS_IMAGE}" \
+	  -t "${DEFAULT_RUNNER_NAME}:v${TAG_VERSION}-${OS_IMAGE}" \
 	  . ${PUSH_ARG}
 
 docker-buildx-dind:
@@ -148,7 +149,7 @@ docker-buildx-dind:
 	  --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
 	  -f actions-runner-dind.${OS_IMAGE}.dockerfile \
 	  -t "${DIND_RUNNER_NAME}:${OS_IMAGE}" \
-	  -t "${DIND_RUNNER_NAME}:v${RUNNER_VERSION}-${OS_IMAGE}" \
+	  -t "${DIND_RUNNER_NAME}:v${TAG_VERSION}-${OS_IMAGE}" \
 	  . ${PUSH_ARG}
 
 docker-buildx-dind-rootless:
@@ -163,5 +164,5 @@ docker-buildx-dind-rootless:
 	  --build-arg DOCKER_VERSION=${DOCKER_VERSION} \
 	  -f actions-runner-dind-rootless.${OS_IMAGE}.dockerfile \
 	  -t "${DIND_ROOTLESS_RUNNER_NAME}:${OS_IMAGE}" \
-	  -t "${DIND_ROOTLESS_RUNNER_NAME}:v${RUNNER_VERSION}-${OS_IMAGE}" \
+	  -t "${DIND_ROOTLESS_RUNNER_NAME}:v${TAG_VERSION}-${OS_IMAGE}" \
 	  . ${PUSH_ARG}


### PR DESCRIPTION
## Description

This pull request changes the following:

* Ensures the docker tag includes the build version when specified

### Related Issues

* Closes #32
