### PR TITLE
chore: add preinstalls for solc-select and build-essentials

### DIFF
--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -87,7 +87,7 @@ RUN apt-get update -y \
     jq \
     skopeo \
     python3-pip \
-    build-essentials \
+    build-essential \
     htop \
     psmisc \
     openssh-client \

--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -87,6 +87,7 @@ RUN apt-get update -y \
     jq \
     skopeo \
     python3-pip \
+    build-essentials \
     htop \
     psmisc \
     openssh-client \
@@ -115,7 +116,8 @@ RUN export RUNNER_ARCH=${TARGETARCH} \
         "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-${DOCKER_ARCH}" \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
-RUN pip3 install ansible
+RUN pip3 install ansible \
+    && pip3 install solc-select
 #########################################
 ## End OS Software Customizations      ##
 #########################################


### PR DESCRIPTION
## Description

This pull request changes the following:

* Preinstalls `solc-select` and `build-essentials`

### Related Issues

* Closes #35 
