### PR TITLE
chore: remove solc-select from the scaleset container image

### DIFF
--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -116,8 +116,7 @@ RUN export RUNNER_ARCH=${TARGETARCH} \
         "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-${DOCKER_ARCH}" \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
-RUN pip3 install ansible \
-    && pip3 install solc-select
+RUN pip3 install ansible
 #########################################
 ## End OS Software Customizations      ##
 #########################################


### PR DESCRIPTION
## Description

This pull request changes the following:

* Removes the `solc-select` command from the Scale Set container image.

### Related Issues

* Closes #37 
