### PR TITLE
chore: replace sersoft-gmbh/setup-gh-cli-action with a step-security maintained one

### DIFF
--- a/.github/workflows/flow-release-legacy-images.yaml
+++ b/.github/workflows/flow-release-legacy-images.yaml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -211,7 +211,7 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/flow-release-scaleset-images.yaml
+++ b/.github/workflows/flow-release-scaleset-images.yaml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -205,7 +205,7 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zxc-retrieve-upstream-versions.yaml
+++ b/.github/workflows/zxc-retrieve-upstream-versions.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zxcron-automatic-releases.yaml
+++ b/.github/workflows/zxcron-automatic-releases.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zxf-forked-pull-request-closer.yaml
+++ b/.github/workflows/zxf-forked-pull-request-closer.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install GH CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@2d02c06e284b7d55e954d6d6406e7a886f45a818 # v2.0.1
+        uses: step-security/setup-gh-cli-action@911a1ad924338cbaed4af8b5f982b605345abb46 # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This pull request changes the following:

sersoft-gmbh/setup-gh-cli-action has to be replaced with the variant maintained by step-security in all workflows utilizing the action.

### Related Issues

* Closes #64 
