### PR TITLE
feat: add support for multiple base operating systems

### DIFF
--- a/.github/workflows/flow-ossf-scorecard.yml
+++ b/.github/workflows/flow-ossf-scorecard.yml
@@ -12,27 +12,24 @@ on:
     branches:
       - main
 
-defaults:
-  run:
-    shell: bash
-
 concurrency:
   group: ossf-scorecard-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  security-events: write
-  id-token: write
-  contents: read
-  actions: read
-  issues: read
-  pull-requests: read
-  checks: read
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard Report
     runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+      issues: read
+      pull-requests: read
+      checks: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/flow-release-scaleset-images.yaml
+++ b/.github/workflows/flow-release-scaleset-images.yaml
@@ -83,7 +83,7 @@ jobs:
 
   safety-checks:
     name: Safety Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - versions
     steps:
@@ -134,7 +134,7 @@ jobs:
 
   update-version:
     name: Update Version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - versions
       - scaleset-image
@@ -176,7 +176,7 @@ jobs:
 
   finalize-release:
     name: Finalize Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - versions
       - update-version

--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -25,6 +25,8 @@ on:
       ## Base Operating System Image
       ## Options include:
       ## - ubuntu-22.04
+      ## - ubuntu-24.04
+      ## - debian-bookworm
       base-os-image:
         description: "Operating System Image:"
         type: string
@@ -104,7 +106,7 @@ permissions:
 jobs:
   create-tool-cache:
     name: Create Tool Cache
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -205,7 +207,7 @@ jobs:
 
   build-scaleset-images:
     name: ${{ inputs.custom-job-label || 'Build' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - create-tool-cache
     steps:
@@ -256,12 +258,12 @@ jobs:
         run: |
           DOCKER_REGISTRY_PREFIX="ghcr.io/${{ github.repository }}"
           IMG_RESULT="push"
-          
+
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
             DOCKER_REGISTRY_PREFIX="local"
             IMG_RESULT="cache"
           fi
-          
+
           echo "prefix=${DOCKER_REGISTRY_PREFIX}" >>"${GITHUB_OUTPUT}"
           echo "operation=${IMG_RESULT}" >>"${GITHUB_OUTPUT}"
 
@@ -282,11 +284,10 @@ jobs:
             ${{ steps.registry.outputs.prefix }}/scaleset-runner:${{ inputs.base-os-image }}
             ${{ steps.registry.outputs.prefix }}/scaleset-runner:v${{ steps.docker-tag.outputs.version }}-${{ inputs.base-os-image }}
           build-args: |
-            TARGETOS=linux
-            TARGETARCH=amd64
+            TARGET_OS=linux
+            TARGET_ARCH=amd64
             RUNNER_VERSION=${{ inputs.runner-version }}
             RUNNER_CONTAINER_HOOKS_VERSION=${{ inputs.runner-container-hooks-version }}
             DOCKER_VERSION=${{ inputs.docker-version }}
             BUILDX_VERSION=${{ inputs.docker-buildx-version }}
             GH_CLI_VERSION=${{ inputs.gh-cli-version }}
-            

--- a/.github/workflows/zxc-retrieve-upstream-versions.yaml
+++ b/.github/workflows/zxc-retrieve-upstream-versions.yaml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   versions:
     name: ${{ inputs.custom-job-label || 'Check' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       tag-version: ${{ steps.tag.outputs.version }}
       runner-version: ${{ steps.runner.outputs.version }}
@@ -143,5 +143,5 @@ jobs:
 
           VERSION="${RELEASE}"
           [[ -n "${BUILD}" ]] && VERSION="${VERSION}+${BUILD}"
-          
+
           echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/zxcron-automatic-releases.yaml
+++ b/.github/workflows/zxcron-automatic-releases.yaml
@@ -35,7 +35,7 @@ jobs:
 
   safety-checks:
     name: Safety Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - versions
     outputs:
@@ -65,12 +65,12 @@ jobs:
             echo "::info title=Release Version::Release scaleset-v${{ needs.versions.outputs.runner }} already exists and may not be redeployed."
             NEEDED="false"
           fi
-          
+
           echo "needed=${NEEDED}" >> "${GITHUB_OUTPUT}"
 
   scaleset-release:
     name: ScaleSet Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - versions
       - safety-checks

--- a/.github/workflows/zxf-forked-pull-request-closer.yaml
+++ b/.github/workflows/zxf-forked-pull-request-closer.yaml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   close-pull-request:
     name: Close Forked Pull Request
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     steps:
       - name: Harden Runner

--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -1,17 +1,19 @@
 # Source: https://github.com/dotnet/dotnet-docker
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
+ARG BASE_OS_VERSION=jammy
+ARG DOTNET_RUNTIME_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:${DOTNET_RUNTIME_VERSION}-${BASE_OS_VERSION} as build
 
-ARG TARGETOS
-ARG TARGETARCH
+ARG TARGET_OS
+ARG TARGET_ARCH
 ARG RUNNER_VERSION
-ARG RUNNER_CONTAINER_HOOKS_VERSION=0.6.1
+ARG RUNNER_CONTAINER_HOOKS_VERSION=0.7.0
 ARG DOCKER_VERSION=25.0.5
 ARG BUILDX_VERSION=0.16.2
 
 RUN apt update -y && apt install curl unzip -y
 
 WORKDIR /actions-runner
-RUN export RUNNER_ARCH=${TARGETARCH} \
+RUN export RUNNER_ARCH=${TARGET_ARCH} \
     && if [ "$RUNNER_ARCH" = "amd64" ]; then export RUNNER_ARCH=x64 ; fi \
     && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-${TARGETOS}-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
     && tar xzf ./runner.tar.gz \
@@ -21,18 +23,18 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
     && unzip ./runner-container-hooks.zip -d ./k8s \
     && rm runner-container-hooks.zip
 
-RUN export RUNNER_ARCH=${TARGETARCH} \
+RUN export RUNNER_ARCH=${TARGET_ARCH} \
     && if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
     && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
-    && curl -fLo docker.tgz https://download.docker.com/${TARGETOS}/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
+    && curl -fLo docker.tgz https://download.docker.com/${TARGET_OS}/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker.tgz \
     && rm -rf docker.tgz \
     && mkdir -p /usr/local/lib/docker/cli-plugins \
     && curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
-        "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
+        "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGET_ARCH}" \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0-jammy
+FROM mcr.microsoft.com/dotnet/runtime-deps:${DOTNET_RUNTIME_VERSION}-${BASE_OS_VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNNER_MANUALLY_TRAP_SIG=1
@@ -99,23 +101,23 @@ RUN curl -fL https://install-cli.jfrog.io | sh \
     && curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver \
     && chmod +x /usr/local/bin/semver
 
-ARG TARGETARCH
+ARG TARGET_ARCH
 ARG GH_CLI_VERSION=2.54.0
-RUN export ARCH=${TARGETARCH} \
+RUN export ARCH=${TARGET_ARCH} \
     && if [ "${ARCH}" = "i386" ]; then export ARCH=386 ; fi \
     && curl -sL https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${ARCH}.tar.gz \
         | tar -xz --wildcards --strip-components=2 -C /usr/local/bin "*/bin/gh" \
     && chmod +x /usr/local/bin/gh
 
 ARG YQ_CLI_VERSION=4.44.3
-RUN export ARCH=${TARGETARCH} \
+RUN export ARCH=${TARGET_ARCH} \
     && if [ "${ARCH}" = "i386" ]; then export ARCH=386 ; fi \
     && curl -fLo /usr/local/bin/yq \
         "https://github.com/mikefarah/yq/releases/download/v${YQ_CLI_VERSION}/yq_linux_${ARCH}" \
     && chmod +x /usr/local/bin/yq
 
 ARG COMPOSE_VERSION=2.29.2
-RUN export RUNNER_ARCH=${TARGETARCH} \
+RUN export RUNNER_ARCH=${TARGET_ARCH} \
     && if [ "${RUNNER_ARCH}" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
     && if [ "${RUNNER_ARCH}" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
     && mkdir -p /usr/local/lib/docker/cli-plugins \

--- a/scaleset/runner/Dockerfile
+++ b/scaleset/runner/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update -y && apt install curl unzip -y
 WORKDIR /actions-runner
 RUN export RUNNER_ARCH=${TARGET_ARCH} \
     && if [ "$RUNNER_ARCH" = "amd64" ]; then export RUNNER_ARCH=x64 ; fi \
-    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-${TARGETOS}-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
+    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-${TARGET_OS}-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz
 


### PR DESCRIPTION
## Description

This pull request updates the CI workflows and the `scaleset/runner/Dockerfile` to support newer base images and standardize environment variable usage. The main goals are to upgrade the runner environments to Ubuntu 24.04, add flexibility for OS and .NET versions, and align variable naming conventions for better clarity and cross-platform compatibility.

**CI Workflow Updates:**

* Upgraded all GitHub Actions workflows to use `ubuntu-24.04` instead of `ubuntu-22.04`, ensuring compatibility with the latest runner environment and system libraries. [[1]](diffhunk://#diff-331eff36498a8508c126c46d8ebe447a297a988858408b8b21fe44035f2dfe5aL41-R41) [[2]](diffhunk://#diff-e92c21666f10407521f8ae870ef0544a9d0350be4faa08b9ee547a8b1482014eL86-R86) [[3]](diffhunk://#diff-e92c21666f10407521f8ae870ef0544a9d0350be4faa08b9ee547a8b1482014eL137-R137) [[4]](diffhunk://#diff-e92c21666f10407521f8ae870ef0544a9d0350be4faa08b9ee547a8b1482014eL179-R179) [[5]](diffhunk://#diff-6f2f38f8278e8dea85dce7b722c0d5f3959419f8ceb8f8b2e94048ca0e893998L107-R109) [[6]](diffhunk://#diff-6f2f38f8278e8dea85dce7b722c0d5f3959419f8ceb8f8b2e94048ca0e893998L208-R210) [[7]](diffhunk://#diff-db75c9843ae421a7994663364b23c5142b240fc13d0a7509652972679ded04ccL61-R61) [[8]](diffhunk://#diff-2655a82c6fb2c7d3236b58a97ba1dee990225fb7f505d905b8d5c9d352b86112L38-R38) [[9]](diffhunk://#diff-2655a82c6fb2c7d3236b58a97ba1dee990225fb7f505d905b8d5c9d352b86112L73-R73) [[10]](diffhunk://#diff-c41d856adf2e87cdff366790483823a4ed3ae335add150ca5d742bcf96800255L37-R37)
* Added support for specifying `ubuntu-24.04` and `debian-bookworm` as base OS image options in workflow inputs, increasing flexibility for future builds.

**Dockerfile and Build Improvements:**

* Updated `scaleset/runner/Dockerfile` to allow specifying the base OS version and .NET runtime version via build arguments, defaulting to `jammy` and `.NET 8.0`. This enables easier upgrades and multi-platform builds.
* Standardized environment variable names from `TARGETOS`/`TARGETARCH` to `TARGET_OS`/`TARGET_ARCH` across Dockerfile and workflow build steps for consistency and clarity. [[1]](diffhunk://#diff-f247ecbc274ce081e7ab9df15624111d07003314b9eac8a1f93540e57815aaa6L2-R16) [[2]](diffhunk://#diff-f247ecbc274ce081e7ab9df15624111d07003314b9eac8a1f93540e57815aaa6L24-R37) [[3]](diffhunk://#diff-f247ecbc274ce081e7ab9df15624111d07003314b9eac8a1f93540e57815aaa6L102-R120) [[4]](diffhunk://#diff-6f2f38f8278e8dea85dce7b722c0d5f3959419f8ceb8f8b2e94048ca0e893998L285-L292)
* Upgraded `RUNNER_CONTAINER_HOOKS_VERSION` from `0.6.1` to `0.7.0` in the Dockerfile, ensuring the latest features and fixes are included.

**Workflow Structure and Permissions:**

* Improved permissions structure in `.github/workflows/flow-ossf-scorecard.yml` by using `permissions: read-all` at the workflow level and reorganizing job definitions for clarity. [[1]](diffhunk://#diff-d2c2c029053d3e990f4e1659224a078ff361bdf038facb53ddeb4d1b35fb77a1L15-R24) [[2]](diffhunk://#diff-d2c2c029053d3e990f4e1659224a078ff361bdf038facb53ddeb4d1b35fb77a1L31-L35)

Let me know if you have questions about any of these changes or need help understanding how to use the new build arguments or workflow options!

### Related Issues

* Closes #143 
