### PR TITLE
feat: add Python 3.12.13 to the scaleset runner tool cache

### DIFF
--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -147,6 +147,14 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Setup Python 3.12.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12.13"
+
+      - name: Pin pip 26.1.2
+        run: python -m pip install --upgrade "pip==26.1.2"
+
       - name: Setup Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:

--- a/.github/workflows/zxc-build-scaleset-images.yaml
+++ b/.github/workflows/zxc-build-scaleset-images.yaml
@@ -151,9 +151,7 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12.13"
-
-      - name: Pin pip 26.1.2
-        run: python -m pip install --upgrade "pip==26.1.2"
+          pip-version: "26.1.2"
 
       - name: Setup Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds an `actions/setup-python` step to the `create-tool-cache` job in `zxc-build-scaleset-images.yaml` so that **Python 3.12.13** is installed into the hosted tool cache (`runner.tool_cache`) that gets archived and baked into the scaleset runner images at `/home/runner/_work/_tool`.
* Pins **pip to 26.1.2** in that interpreter via `python -m pip install --upgrade "pip==26.1.2"`, so the cached Python ships with a known pip version.

The step is placed alongside the other language-runtime setups (Java / Node / Go), is SHA-pinned per repo convention (`# v6.2.0`), and rides into every base-OS image because the tool cache is OS-independent.

### Related Issues

* Closes #